### PR TITLE
fix raindrop missing pagination for returnAll

### DIFF
--- a/packages/nodes-base/nodes/Raindrop/Raindrop.node.ts
+++ b/packages/nodes-base/nodes/Raindrop/Raindrop.node.ts
@@ -165,12 +165,31 @@ export class Raindrop implements INodeType {
 
 						const collectionId = this.getNodeParameter('collectionId', i);
 						const endpoint = `/raindrops/${collectionId}`;
-						responseData = await raindropApiRequest.call(this, 'GET', endpoint, {}, {});
-						responseData = responseData.items;
 
-						if (!returnAll) {
+						if (returnAll) {
+							let page = 0;
+							const perpage = 50; // max supported by raindrop
+							let pageResult: any = [];
+							responseData = [];
+							do {
+								pageResult = (
+									await raindropApiRequest.call(this, 'GET', endpoint, { perpage, page }, {})
+								).items;
+
+								responseData.push(...pageResult);
+
+								page++;
+							} while (pageResult.length === perpage);
+						} else {
 							const limit = this.getNodeParameter('limit', 0);
-							responseData = responseData.slice(0, limit);
+							responseData = await raindropApiRequest.call(
+								this,
+								'GET',
+								endpoint,
+								{ perpage: limit },
+								{},
+							);
+							responseData = responseData.items;
 						}
 					} else if (operation === 'update') {
 						// ----------------------------------


### PR DESCRIPTION
Included fix for missing pagination in Raindrop node for GetAll API.
It also requests for limited number of documents through API interface only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Getting all Raindrop bookmarks now reliably returns the complete set across pages.
  * When a limit is specified, the correct number of bookmarks is returned without overfetching or truncation issues.

* **Performance**
  * Improved efficiency by paginating fetches (50 per page) and matching page size to the requested limit, reducing unnecessary data transfer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->